### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/herculeum/sphinx/items.py
+++ b/src/herculeum/sphinx/items.py
@@ -208,7 +208,7 @@ class ItemDescriptionDirective(Directive):
     def run(self, config):
         env = self.state.document.settings.env
 
-        targetid = "itemdescription-%d" % env.new_serialno('itemdescription')
+        targetid = "itemdescription-{0:d}".format(env.new_serialno('itemdescription'))
         targetnode = nodes.target('', '', ids=[targetid])
 
         para = nodes.paragraph()

--- a/src/pyherc/ai/heapset.py
+++ b/src/pyherc/ai/heapset.py
@@ -46,7 +46,7 @@ class HeapSet(list):
 
     def append(self, item):
         if item in self.pos_dict:
-            raise ValueError("item %s appended twice."%str(item))
+            raise ValueError("item {0!s} appended twice.".format(str(item)))
         self.pos_dict[item] = self.pop_begin + len(self)
         list.append(self, item)
 
@@ -77,4 +77,4 @@ class HeapSet(list):
         return self.pos_dict[item] - self.pop_begin
 
     def __str__(self):
-        return list.__str__(self) + str(self.pos_dict) + "pops %d"%self.pop_begin
+        return list.__str__(self) + str(self.pos_dict) + "pops {0:d}".format(self.pop_begin)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tuturto:pyherc?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:tuturto:pyherc?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)