### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/src/herculeum/ai/simple.py
+++ b/src/herculeum/ai/simple.py
@@ -73,7 +73,7 @@ class FlockingHerbivore():
                 loc_x = abs(creature.location[0] - character.location[0])
                 loc_y = abs(creature.location[1] - character.location[1])
                 distance = math.sqrt(loc_x * loc_x + loc_y * loc_y)
-                if shortest_distance != None:
+                if shortest_distance is not None:
                     if distance < shortest_distance:
                         shortest_distance = distance
                         closest_creature = creature
@@ -81,7 +81,7 @@ class FlockingHerbivore():
                     shortest_distance = distance
                     closest_creature = creature
 
-        if shortest_distance != None:
+        if shortest_distance is not None:
             if shortest_distance <= 2:
                 #seek player instead
                 loc_x = abs(player.location[0] - character.location[0])

--- a/src/herculeum/ai/skeleton.py
+++ b/src/herculeum/ai/skeleton.py
@@ -65,7 +65,7 @@ class SkeletonWarriorAI():
         """
         del self.character.short_term_memory[:]
 
-        if self.character.inventory.weapon == None:
+        if self.character.inventory.weapon is None:
             self._wield_weapon(action_factory)
 
         c_location = self.character.location
@@ -98,7 +98,7 @@ class SkeletonWarriorAI():
         """
         weapons = [item for item in
                    self.character.inventory
-                   if item.weapon_data != None]
+                   if item.weapon_data is not None]
 
         if weapons:
             equip(self.character,
@@ -112,7 +112,7 @@ class SkeletonWarriorAI():
         character = self.character
         level = self.character.level
 
-        while (self.destination == None
+        while (self.destination is None
                or character.location == self.destination):
 
             self.destination = find_free_space(level)

--- a/src/herculeum/sphinx/helpers.py
+++ b/src/herculeum/sphinx/helpers.py
@@ -44,7 +44,7 @@ def with_config(fn):
         Inject configuration
         """
 
-        if herculeum.sphinx.helpers.config == None:
+        if herculeum.sphinx.helpers.config is None:
            herculeum.sphinx.helpers.qt_app = QApplication([])
            herculeum.sphinx.helpers.world = Model()
            herculeum.sphinx.helpers.config = Configuration(
@@ -64,5 +64,5 @@ def shutdown_application(app, env, docname):
     """
     Shutdown qt application
     """
-    if herculeum.sphinx.helpers.qt_app != None:
+    if herculeum.sphinx.helpers.qt_app is not None:
         herculeum.sphinx.helpers.qt_app = None

--- a/src/herculeum/sphinx/items.py
+++ b/src/herculeum/sphinx/items.py
@@ -126,10 +126,10 @@ def make_weapon_table(env, node):
 
         item = item_entry['item']
 
-        if item.weapon_data != None:
+        if item.weapon_data is not None:
             damage_str = str.join(' / ', [str(x[0]) for x in item.weapon_data.damage])
             damage_types_str = str.join(' / ', [str(x[1]) for x in item.weapon_data.damage])
-        elif item.ammunition_data != None:
+        elif item.ammunition_data is not None:
             damage_str = str.join(' / ', [str(x[0]) for x in item.ammunition_data.damage])
             damage_types_str = str.join(' / ', [str(x[1]) for x in item.ammunition_data.damage])
 
@@ -151,12 +151,12 @@ def make_weapon_table(env, node):
         else:
             weapon_weight = ' '
 
-        if item.weapon_data != None:
+        if item.weapon_data is not None:
             row_node = make_row(item.name, damage_str,
                                 item.weapon_data.critical_range,
                                 item.weapon_data.critical_damage,
                                 damage_types_str, weapon_type, weapon_weight)
-        elif item.ammunition_data != None:
+        elif item.ammunition_data is not None:
             row_node = make_row(item.name, damage_str,
                                 item.ammunition_data.critical_range,
                                 item.ammunition_data.critical_damage,

--- a/src/herculeum/test/matchers/itemglyph.py
+++ b/src/herculeum/test/matchers/itemglyph.py
@@ -46,9 +46,9 @@ class ItemGlyphMatcher(BaseMatcher):
         :returns: True if matching, otherwise False
         :rtype: Boolean
         """
-        if (item != None
+        if (item is not None
                 and hasattr(item, 'item')
-                and item.item != None
+                and item.item is not None
                 and item.item.name == self.item_name):
             return True
         else:

--- a/src/herculeum/ui/controllers/inventory.py
+++ b/src/herculeum/ui/controllers/inventory.py
@@ -52,19 +52,19 @@ class InventoryController():
             drink(self.character,
                   item)
         elif is_weapon(item):
-            if self.character.inventory.weapon != None:
+            if self.character.inventory.weapon is not None:
                 unequip(self.character,
                         self.character.inventory.weapons)
             equip(self.character,
                   item)
         elif is_armour(item):
-            if self.character.inventory.armour != None:
+            if self.character.inventory.armour is not None:
                 unequip(self.character,
                         self.character.inventory.armour)
             equip(self.character,
                   item)
         elif is_boots(item):
-            if self.character.inventory.boots != None:
+            if self.character.inventory.boots is not None:
                 unequip(self.character,
                         self.character.inventory.boots)
             equip(self.character,
@@ -104,14 +104,14 @@ class InventoryController():
         """
         item_description = item.get_name(self.character,
                                          True)
-        if item.weapon_data != None:
+        if item.weapon_data is not None:
             data = item.weapon_data
             item_description += '\ndamage: '
             item_description += ' / '.join((str(x[0]) for x in data.damage))
             item_description += ' ('
             item_description += ' / '.join((str(x[1]) for x in data.damage))
             item_description += ')\n'
-        elif item.armour_data != None:
+        elif item.armour_data is not None:
             data = item.armour_data
             item_description += '\ndamage reduction: {0}\n'.format(data.damage_reduction)
             item_description += 'speed modifier: {0}\n'.format(data.speed_modifier)

--- a/src/herculeum/ui/gui/inventory.py
+++ b/src/herculeum/ui/gui/inventory.py
@@ -270,7 +270,7 @@ class CharacterInventoryWidget(QWidget):
         """
         item = [x for x in self.items
                 if x.display.objectName() == 'active_inventorybox'][0].item
-        if item != None:
+        if item is not None:
             if key in self.config.action_a:
                 self.ItemActionA.emit(item)
             elif key in self.config.action_b:
@@ -623,7 +623,7 @@ class ItemBox(QWidget):
         .. versionadded:: 0.8
         """
         item = self.get_current_slot().item
-        if item != None:
+        if item is not None:
             if key in self.config.action_a:
                 self.ItemActionA.emit(item)
             elif key in self.config.action_b:
@@ -682,7 +682,7 @@ class ItemBox(QWidget):
         """
         slot = self.get_current_slot()
 
-        if slot == None:
+        if slot is None:
             return None
 
         index = self.items.index(slot)
@@ -780,7 +780,7 @@ class ItemGlyph(QWidget):
         """
         self.display.setObjectName('active_inventorybox')
         self.display.setStyle(QApplication.style())
-        if self.item != None:
+        if self.item is not None:
             self.ItemFocused.emit(self.item)
 
     def focusOutEvent(self, event):
@@ -811,7 +811,7 @@ class ItemGlyph(QWidget):
         """
         self.item = item
 
-        if item != None:
+        if item is not None:
             if is_ammunition(item):
                 count = item.ammunition_data.count
             elif is_trap_bag(item):
@@ -835,7 +835,7 @@ class ItemGlyph(QWidget):
 
             self.icon = icon
         else:
-            if self.default_icon == None:
+            if self.default_icon is None:
                 self.icon = QPixmap(':transparent.png')
             else:
                 self.icon = self.default_icon

--- a/src/herculeum/ui/gui/map.py
+++ b/src/herculeum/ui/gui/map.py
@@ -429,7 +429,7 @@ class PlayMapWidget(QWidget):
             self.model.end_condition = DIED_IN_DUNGEON
 
         while (next_creature != player
-                and next_creature != None
+                and next_creature is not None
                 and self.model.end_condition == 0):
             next_creature.act(model = self.model,
                               action_factory = self.action_factory,
@@ -529,7 +529,7 @@ class PlayMapWidget(QWidget):
         level = player.level
         items = list(get_items(level, player.location))
 
-        if items != None and len(items) > 0:
+        if items is not None and len(items) > 0:
             pick_up(player,
                     items[0])
 

--- a/src/herculeum/ui/text/inventory.py
+++ b/src/herculeum/ui/text/inventory.py
@@ -95,7 +95,7 @@ class InventoryScreen():
                     if index < len(self.character.inventory):
                         item = self.character.inventory[index]
 
-                if item != None:
+                if item is not None:
                     if key == 'u':
                         self.inventory_controller.use_item(item)
                     elif key == 'r':

--- a/src/herculeum/ui/text/map.py
+++ b/src/herculeum/ui/text/map.py
@@ -95,7 +95,7 @@ class MapScreen():
         self.refresh_screen()
         player = self.model.player
 
-        while self.model.end_condition == 0 and player.level != None:
+        while self.model.end_condition == 0 and player.level is not None:
             next_creature = self.model.get_next_creature(self.rules_engine)
 
             if next_creature == player:
@@ -180,7 +180,7 @@ class MapScreen():
         level = player.level
         items = level.get_items_at(player.location)
 
-        if items != None and len(items) > 0:
+        if items is not None and len(items) > 0:
             pick_up(player,
                     items[0])
 
@@ -195,7 +195,7 @@ class MapScreen():
         player = self.model.player
         level = player.level
 
-        if level == None:
+        if level is None:
             return
 
         for column_number, column in enumerate(level.floor):
@@ -208,7 +208,7 @@ class MapScreen():
         for column_number, column in enumerate(level.walls):
             for row_number, tile in enumerate(column):
                 glyph_number = self.surface_manager.get_icon(tile)
-                if glyph_number != None:
+                if glyph_number is not None:
                     self.screen.addch(row_number + 1,
                                       column_number,
                                       ord(glyph_number),

--- a/src/herculeum/ui/text/start_game.py
+++ b/src/herculeum/ui/text/start_game.py
@@ -48,7 +48,7 @@ class StartGameScreen():
 
         selection = None
 
-        while selection == None:
+        while selection is None:
             selection = self.screen.getch()
 
             try:

--- a/src/herculeum/ui/text/surface_manager.py
+++ b/src/herculeum/ui/text/surface_manager.py
@@ -62,7 +62,7 @@ class CursesSurfaceManager():
         if not key in self.icons:
             self.icons[key] = ascii_char
 
-            if attributes == None:
+            if attributes is None:
                 used_attributes = curses.A_NORMAL | self.get_attribute_by_name('white')
             else:
                 used_attributes = curses.A_NORMAL

--- a/src/pyherc/ai/heapset.py
+++ b/src/pyherc/ai/heapset.py
@@ -40,7 +40,7 @@ class HeapSet(list):
     def __init__(self, iterator = None):
         self.pos_dict = {}
         self.pop_begin = 0
-        if iterator != None:
+        if iterator is not None:
             for i in iterator:
                 self.append(i)
 
@@ -60,7 +60,7 @@ class HeapSet(list):
 
 
     def pop(self, pos = None):
-        if pos == None:
+        if pos is None:
             item = list.pop(self)
             pos = len(self)
         elif pos == 0:

--- a/src/pyherc/ai/pathfinding.py
+++ b/src/pyherc/ai/pathfinding.py
@@ -140,7 +140,7 @@ def a_star(start, goal, a_map):
         x  = pyheapq.heappop(scoreHeap)
 
         if x.node == goal:
-            if lastItem == None or lastItem.g_score > x.g_score:
+            if lastItem is None or lastItem.g_score > x.g_score:
                 lastItem = x
 
             if not any(scoreHeap) or scoreHeap[0].f_score > lastItem.g_score:
@@ -168,7 +168,7 @@ def a_star(start, goal, a_map):
 
             y = HeapItem(node_y, goal, a_map, tentative_g_score)
 
-            if oldy == None:
+            if oldy is None:
                 openDict[node_y] = y
                 came_from[node_y] = x.node
 
@@ -182,7 +182,7 @@ def a_star(start, goal, a_map):
 
                 pyheapq.updateheapvalue(scoreHeap, scoreHeap.index(oldy), y)
 
-    if lastItem != None:
+    if lastItem is not None:
         return [start] + reconstruct_path(came_from,goal), came_from, updateset
     else:
         return [], came_from, updateset

--- a/src/pyherc/test/matchers/map_connectivity.py
+++ b/src/pyherc/test/matchers/map_connectivity.py
@@ -87,7 +87,7 @@ class MapConnectivity(BaseMatcher):
         points = []
 
         for location, tile in get_tiles(level):
-            if tile['\ufdd0:wall'] == None:
+            if tile['\ufdd0:wall'] is None:
                 points.append(location)
 
         return points

--- a/src/pyherc/test/unit/test_generator_utils.py
+++ b/src/pyherc/test/unit/test_generator_utils.py
@@ -43,15 +43,15 @@ class TestGeneratorUtils():
         Test that BSP section can be split horizontally
         """
         section = pyherc.generators.utils.BSPSection((0, 0), (20, 20), None)
-        assert(section.node1 == None)
-        assert(section.node2 == None)
+        assert(section.node1 is None)
+        assert(section.node2 is None)
 
         section.split(direction = 1)
         # 1 split horizontal
         # 2 split vertical
 
-        assert(section.node1 != None)
-        assert(section.node2 != None)
+        assert(section.node1 is not None)
+        assert(section.node2 is not None)
 
         assert(section.node1.corner1[0] == section.node2.corner1[0])
         assert(section.node1.corner1[1] == 0)
@@ -65,15 +65,15 @@ class TestGeneratorUtils():
         Test that bsp section can split vertical
         """
         section = pyherc.generators.utils.BSPSection((0, 0), (20, 20), None)
-        assert(section.node1 == None)
-        assert(section.node2 == None)
+        assert(section.node1 is None)
+        assert(section.node2 is None)
 
         section.split(direction = 2)
         # 1 split horisontal
         # 2 split vertical
 
-        assert(section.node1 != None)
-        assert(section.node2 != None)
+        assert(section.node1 is not None)
+        assert(section.node2 is not None)
 
         assert(section.node1.corner1[0] == 0)
         assert(section.node1.corner1[1] == 0)
@@ -87,13 +87,13 @@ class TestGeneratorUtils():
         Test that bsp split does not try to split when there is not enough space
         """
         section = pyherc.generators.utils.BSPSection((0, 0), (10, 10), None)
-        assert(section.node1 == None)
-        assert(section.node2 == None)
+        assert(section.node1 is None)
+        assert(section.node2 is None)
 
         section.split()
 
-        assert(section.node1 == None)
-        assert(section.node2 == None)
+        assert(section.node1 is None)
+        assert(section.node2 is None)
 
     def test_getAreaQueue(self):
         """


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tuturto:pyherc?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:tuturto:pyherc?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
